### PR TITLE
GitopsCluster readiness reflects ControlPlaneReady on capiCluster

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -5,8 +5,10 @@ const (
 	SecretFoundReason string = "SecretFound"
 	// WaitingForSecretReason signals that a given secret has not been found.
 	WaitingForSecretReason string = "WaitingForSecret"
-	// CAPIClusterFoundReason signals that a given CAPI cluster has been found.
-	CAPIClusterFoundReason string = "CAPIClusterFound"
+	// WaitingForControlPlaneReadyStatusReason  signals that a given CAPI cluster has been found but its ControlPlaneReady status is false
+	WaitingForControlPlaneReadyStatusReason string = "WaitingForControlPlaneReadyStatus"
+	// ControlPlaneReadyStatusReason signals that a cluster is found and it has a ControlPlaneReady=true condition
+	ControlPlaneReadyStatusReason string = "ControlPlaneReadyStatus"
 	// WaitingForCAPIClusterReason signals that a given CAPI cluster has not been found.
 	WaitingForCAPIClusterReason string = "WaitingForCAPICluster"
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -37,7 +36,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 


### PR DESCRIPTION
- New crack at cluster readiness.
- This time we check Cluster.Status.ControlPlaneReady
  - https://github.com/kubernetes-sigs/cluster-api/blob/main/api/v1beta1/cluster_types.go#L272
  - Should be provided by all CAPI providers