### PR TITLE
Generate CRDs into a ./crds folder instead of ./templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ envtest: ## Download envtest-setup locally if necessary.
 HELMIFY = $(shell pwd)/bin/helmify
 .PHONY: helmify
 helmify:
-	$(call go-get-tool,$(HELMIFY),github.com/arttor/helmify/cmd/helmify@v0.3.10)
+	$(call go-get-tool,$(HELMIFY),github.com/arttor/helmify/cmd/helmify@v0.3.18)
 
 .PHONY: helm
 helm: manifests kustomize helmify
-	$(KUSTOMIZE) build config/default | $(HELMIFY) ../weave-gitops-enterprise/charts/cluster-controller
+	$(KUSTOMIZE) build config/default | $(HELMIFY) -crd-dir ../weave-gitops-enterprise/charts/cluster-controller
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Related https://github.com/weaveworks/weave-gitops-enterprise/issues/1217