### PR TITLE
Regenerate and fix the namespace.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# VERSION defines the project version for the bundle.
+# Update this value when you upgrade the version of your project.
+# To re-generate a bundle for another specific version without changing the standard setup, you can:
+# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
+# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
+VERSION ?= 0.0.1
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -46,6 +52,11 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+.PHONY: release
+release: manifests kustomize ## Generate a release file
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > cluster-controller-v$(VERSION).yaml
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the gitops v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=gitops.weave.works
+// +kubebuilder:object:generate=true
+// +groupName=gitops.weave.works
 package v1alpha1
 
 import (

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: cluster-controller-system
+namespace: flux-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named


### PR DESCRIPTION
This changes the default namespace to reside in `flux-system` and adds a new Makefile target `release`.

`$ VERSION=0.0.2 IMG=test/image:tag make release` will generate a file that contains a set of resources that can be applied to a cluster to install the image.