### PR TITLE
Refactor the order of updating the status.

### DIFF
--- a/controllers/gitopscluster_controller.go
+++ b/controllers/gitopscluster_controller.go
@@ -206,29 +206,19 @@ func (r *GitopsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		log.Info("CAPI Cluster found", "CAPI cluster", name)
 
-		updated := false
 		if !capiCluster.Status.ControlPlaneReady {
 			conditions.MarkFalse(cluster, meta.ReadyCondition, gitopsv1alpha1.WaitingForControlPlaneReadyStatusReason, "Waiting for ControlPlaneReady status")
-			updated = true
+		} else {
+			conditions.MarkTrue(cluster, meta.ReadyCondition, gitopsv1alpha1.ControlPlaneReadyStatusReason, "")
 		}
 		if clusterv1.ClusterPhase(capiCluster.Status.Phase) == clusterv1.ClusterPhaseProvisioned {
 			conditions.MarkTrue(cluster, gitopsv1alpha1.ClusterProvisionedCondition, gitopsv1alpha1.ClusterProvisionedReason, "CAPI Cluster has been provisioned")
-			updated = true
 		}
-
-		if updated {
-			if err := r.Status().Update(ctx, cluster); err != nil {
-				log.Error(err, "failed to update Cluster status")
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
-		}
-
-		conditions.MarkTrue(cluster, meta.ReadyCondition, gitopsv1alpha1.ControlPlaneReadyStatusReason, "")
 		if err := r.Status().Update(ctx, cluster); err != nil {
 			log.Error(err, "failed to update Cluster status")
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/gitopscluster_controller_test.go
+++ b/controllers/gitopscluster_controller_test.go
@@ -174,6 +174,7 @@ func TestReconcile(t *testing.T) {
 					Namespace: testNamespace,
 				}, func(c *clusterv1.Cluster) {
 					c.Status.ControlPlaneReady = true
+					c.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioned)
 				}),
 			},
 			obj: types.NamespacedName{Namespace: testNamespace, Name: testName},


### PR DESCRIPTION
This fixes a bug going to Ready from Provisioned, where the provisioned would apply the update, and return before the ready was applied.