### PR TITLE
Default logging to Production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./main.go --zap-devel=true
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
This changes the configuration for the controller-runtime zap logging to use "production" by default.

The run target in the Makefile is updated to switch back to devel mode logging when running locally.