### PR TITLE
Switch to flux logging package

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"os"
 	"time"
 
@@ -25,6 +24,8 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/fluxcd/pkg/runtime/logger"
+	flag "github.com/spf13/pflag"
 	gitopsv1alpha1 "github.com/weaveworks/cluster-controller/api/v1alpha1"
 	"github.com/weaveworks/cluster-controller/controllers"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +34,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -77,13 +77,11 @@ func main() {
 		options.DefaultRequeueTime = defaultTime
 	}
 
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
+	var logOptions logger.Options
+	logOptions.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger(logger.NewLogger(logOptions))
 
 	if options.CAPIEnabled {
 		utilruntime.Must(clusterv1.AddToScheme(scheme))


### PR DESCRIPTION
This drops the controller-runtime defaults for setting up logging in favour of the flux logging package which aligns the log output with Flux.