### PR TITLE
Update main.yaml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup | Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
       - name: Setup | Go Cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
This bumps the version used in the post-integration run to use Go 1.17 too