### PR TITLE
Add clusterconnectivity to gitopscluster schema

### DIFF
--- a/api/v1alpha1/gitopscluster_types.go
+++ b/api/v1alpha1/gitopscluster_types.go
@@ -57,14 +57,16 @@ func (in *GitopsCluster) SetConditions(conditions []metav1.Condition) {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
+// +kubebuilder:printcolumn:name="ClusterConnectivity",type="string",JSONPath=".status.conditions[?(@.type==\"ClusterConnectivity\")].status",description=""
 
 // GitopsCluster is the Schema for the gitopsclusters API
 type GitopsCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   GitopsClusterSpec   `json:"spec,omitempty"`
-	Status GitopsClusterStatus `json:"status,omitempty"`
+	Spec                GitopsClusterSpec   `json:"spec,omitempty"`
+	Status              GitopsClusterStatus `json:"status,omitempty"`
+	ClusterConnectivity string              `json:"clusterConnectivity,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/gitopscluster_types.go
+++ b/api/v1alpha1/gitopscluster_types.go
@@ -66,7 +66,6 @@ type GitopsCluster struct {
 
 	Spec                GitopsClusterSpec   `json:"spec,omitempty"`
 	Status              GitopsClusterStatus `json:"status,omitempty"`
-	ClusterConnectivity string              `json:"clusterConnectivity,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/gitops.weave.works_gitopsclusters.yaml
+++ b/config/crd/bases/gitops.weave.works_gitopsclusters.yaml
@@ -38,8 +38,6 @@ spec:
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
-          clusterConnectivity:
-            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/config/crd/bases/gitops.weave.works_gitopsclusters.yaml
+++ b/config/crd/bases/gitops.weave.works_gitopsclusters.yaml
@@ -25,6 +25,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ClusterConnectivity")].status
+      name: ClusterConnectivity
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -34,6 +37,8 @@ spec:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          clusterConnectivity:
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2749

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed and how was it implemented?**
Add `ClusterConnectivity` status to gitopsset schema and CRD to be able to view the clusterConnectivity when listing gitopssets in WGE as the following 
![Screenshot from 2023-05-09 18-52-53](https://github.com/weaveworks/cluster-controller/assets/17128393/7789c383-726f-4b2a-a7d0-70d3fd02746a)


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
manual test
