### PR TITLE
Tweaking dependabot to just raise PRs for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "daily"
     reviewers:
       - "weaveworks/pesto"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
🎶 Feel free to close this PR in case you want to have dependency updates managed by Depenadbot 🎶

Tweaking Dependabot to just raising PRs for security updates, not version updates. 

To have version updates managed by Dependabot was not in the original scope so it is an unintended consequence. This PR tries to revert this behavior as the documentation [suggests](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)