### PR TITLE
Renamed dockerhub secrets to align at the level of the org. It allows…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,8 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
+          password: ${{ secrets.WGE_DOCKER_IO_USER }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
Renamed dockerhub secrets to align at the level of the org. It allow dependabot to use them.

More info https://github.com/weaveworks/corp/issues/3627#issuecomment-1655420011

⚠️ Before Merging ⚠️
- Verify that you could see the secrets form the PR in [dependabot secrets](https://github.com/weaveworks/cluster-controller/settings/secrets/dependabot)
- Recreate the dockerhub secrets in [github actions](https://github.com/weaveworks/cluster-controller/settings/secrets/actions) with the name in the PR

