### PR TITLE
Add status message when referencing secrets.

### DIFF
--- a/controllers/gitopscluster_controller.go
+++ b/controllers/gitopscluster_controller.go
@@ -50,11 +50,6 @@ const GitOpsClusterFinalizer = "clusters.gitops.weave.works"
 // that it should have a ready Provisioned condition.
 const GitOpsClusterProvisionedAnnotation = "clusters.gitops.weave.works/provisioned"
 
-// GitOpsClusterNoSecretFinalizerAnnotation if applied to a GitopsCluster
-// indicates that we should not wait for the secret to be removed before
-// allowing the cluster to be removed.
-const GitOpsClusterNoSecretFinalizerAnnotation = "clusters.gitops.weave.works/no-secret-finalizer"
-
 const (
 	// SecretNameIndexKey is the key used for indexing secret
 	// resources based on their name.
@@ -134,7 +129,7 @@ func (r *GitopsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// examine DeletionTimestamp to determine if object is under deletion
 	if cluster.ObjectMeta.DeletionTimestamp.IsZero() {
-		hasSkipFinalizer := metav1.HasAnnotation(cluster.ObjectMeta, GitOpsClusterNoSecretFinalizerAnnotation)
+		hasSkipFinalizer := metav1.HasAnnotation(cluster.ObjectMeta, gitopsv1alpha1.GitOpsClusterNoSecretFinalizerAnnotation)
 		if (cluster.Spec.SecretRef != nil || cluster.Spec.CAPIClusterRef != nil) && !hasSkipFinalizer {
 			if !controllerutil.ContainsFinalizer(cluster, GitOpsClusterFinalizer) {
 				controllerutil.AddFinalizer(cluster, GitOpsClusterFinalizer)
@@ -192,7 +187,7 @@ func (r *GitopsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		log.Info("Secret found", "secret", name)
 
-		conditions.MarkTrue(cluster, meta.ReadyCondition, gitopsv1alpha1.SecretFoundReason, "")
+		conditions.MarkTrue(cluster, meta.ReadyCondition, gitopsv1alpha1.SecretFoundReason, "Referenced secret is available")
 		if err := r.Status().Update(ctx, cluster); err != nil {
 			log.Error(err, "failed to update Cluster status")
 			return ctrl.Result{}, err

--- a/controllers/gitopscluster_controller_test.go
+++ b/controllers/gitopscluster_controller_test.go
@@ -80,9 +80,10 @@ func TestReconcile(t *testing.T) {
 				CAPIEnabled:        true,
 				DefaultRequeueTime: defaultRequeueTime,
 			},
-			requeueAfter:  defaultRequeueTime,
-			wantCondition: meta.ReadyCondition,
-			wantStatus:    "True",
+			requeueAfter:      defaultRequeueTime,
+			wantCondition:     meta.ReadyCondition,
+			wantStatus:        "True",
+			wantStatusMessage: "Referenced secret is available",
 		},
 		{
 			name: "non-CAPI cluster has provisioned annotation",
@@ -462,7 +463,7 @@ func TestFinalizers(t *testing.T) {
 			makeTestCluster(func(c *gitopsv1alpha1.GitopsCluster) {
 				c.ObjectMeta.Namespace = "test-ns"
 				c.ObjectMeta.Annotations = map[string]string{
-					controllers.GitOpsClusterNoSecretFinalizerAnnotation: "true",
+					gitopsv1alpha1.GitOpsClusterNoSecretFinalizerAnnotation: "true",
 				}
 				c.Spec.SecretRef = &meta.LocalObjectReference{
 					Name: "test-cluster",


### PR DESCRIPTION
When a GitopsCluster references an explicit secret, this improves the status message to indicate that the secret is found.

For example, just now...

```
NAME                   AGE     READY   STATUS   CLUSTERCONNECTIVITY
pestomarketplacetest   7m57s   True             True
```

This will indicate that the secret has been found.